### PR TITLE
feat: add support for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,15 @@ export default defineConfig({
 })
 ```
 
+## Debugging
+
+Run your tests with the following environment variable to log the debugging
+output:
+
+```bash
+DEBUG=cypress-vite
+```
+
 ## Credits
 
 Thanks to

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
+    "@types/debug": "^4.1.7",
     "@types/node": "^18.7.18",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
@@ -62,5 +63,8 @@
     "tsup": "^6.2.3",
     "typescript": "^4.8.3",
     "vite": "^3.1.3"
+  },
+  "dependencies": {
+    "debug": "^4.3.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,10 +6,12 @@ importers:
     specifiers:
       '@commitlint/cli': ^17.1.2
       '@commitlint/config-conventional': ^17.1.0
+      '@types/debug': ^4.1.7
       '@types/node': ^18.7.18
       '@typescript-eslint/eslint-plugin': ^5.38.0
       '@typescript-eslint/parser': ^5.38.0
       cypress: ^10.8.0
+      debug: ^4.3.4
       eslint: ^8.23.1
       eslint-config-prettier: ^8.5.0
       husky: ^8.0.1
@@ -19,9 +21,12 @@ importers:
       tsup: ^6.2.3
       typescript: ^4.8.3
       vite: ^3.1.3
+    dependencies:
+      debug: 4.3.4
     devDependencies:
       '@commitlint/cli': 17.1.2
       '@commitlint/config-conventional': 17.1.0
+      '@types/debug': 4.1.7
       '@types/node': 18.7.18
       '@typescript-eslint/eslint-plugin': 5.38.0_wsb62dxj2oqwgas4kadjymcmry
       '@typescript-eslint/parser': 5.38.0_irgkl5vooow2ydyo6aokmferha
@@ -747,12 +752,22 @@ packages:
     resolution: {integrity: sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==}
     dev: true
 
+  /@types/debug/4.1.7:
+    resolution: {integrity: sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==}
+    dependencies:
+      '@types/ms': 0.7.31
+    dev: true
+
   /@types/json-schema/7.0.11:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
     dev: true
 
   /@types/minimist/1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
+    dev: true
+
+  /@types/ms/0.7.31:
+    resolution: {integrity: sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==}
     dev: true
 
   /@types/node/14.18.29:
@@ -1614,7 +1629,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
 
   /debug/4.3.4_supports-color@8.1.1:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -3020,7 +3034,6 @@ packages:
 
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
-    dev: true
 
   /ms/2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}

--- a/src/resolveConfig.ts
+++ b/src/resolveConfig.ts
@@ -11,8 +11,9 @@ let resolvedUserConfig: UserConfig | undefined = undefined
 const configEnv: ConfigEnv = { command: 'build', mode: 'development' }
 
 export function resolveConfig(userConfigPath: string) {
-  loadConfigFromFile(configEnv, userConfigPath).then((result) => {
+  return loadConfigFromFile(configEnv, userConfigPath).then((result) => {
     resolvedUserConfig = result?.config
+    return resolvedUserConfig
   })
 }
 


### PR DESCRIPTION
This PR adds [ debug ](https://www.npmjs.com/package/debug) for debugging the plugin process. Just run your tests with the following environment variable to log the debugging output:

```bash
DEBUG=cypress-vite
```
