### PR TITLE
fix: override `ouput.manualChunks` using `false`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,9 +84,9 @@ function vitePreprocessor(
         },
         rollupOptions: {
           output: {
-            manualChunks: undefined, // override any manualChunks from the user config because they don't work with UMD
-          }
-        }
+            manualChunks: false as any, // override any manualChunks from the user config because they don't work with UMD
+          },
+        },
       },
     }
 


### PR DESCRIPTION
It seems that #58 doesn't solve the #57, and we should use `false` value to override user config. Resolves #66.