### PR TITLE
fix: add rolldown compatibility and fix rollup bug

### DIFF
--- a/src/vitePreprocessor.ts
+++ b/src/vitePreprocessor.ts
@@ -81,8 +81,7 @@ function vitePreprocessor(
         rollupOptions: {
           output: {
             // override any manualChunks from the user config because they don't work with UMD
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            manualChunks: false as any,
+            manualChunks: () => null,
           },
         },
       },


### PR DESCRIPTION
`manualChunks` cannot be a boolean, that is invalid even in rollup.
But with rolldown it will hard break. Instead just always return `null` to disable manual chunks