### PR TITLE
fix: manualChunks deletion / override

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,3 +2,12 @@ export const maybeMap = <I, O>(
   value: I | I[],
   modifier: (item: I) => O,
 ): O | O[] => (Array.isArray(value) ? value.map(modifier) : modifier(value))
+
+export const omit = <T extends object, K extends keyof T>(
+  obj: T,
+  ...keys: K[]
+): Omit<T, K> => {
+  const ret = { ...obj }
+  keys.forEach((key) => delete ret[key])
+  return ret
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,4 @@
+export const maybeMap = <I, O>(
+  value: I | I[],
+  modifier: (item: I) => O,
+): O | O[] => (Array.isArray(value) ? value.map(modifier) : modifier(value))

--- a/src/vitePrebuild.ts
+++ b/src/vitePrebuild.ts
@@ -65,21 +65,21 @@ export function getVitePrebuilder(userConfig?: InlineConfig | string) {
 
     debug(`Pre-building ${files.length} files with Vite.`)
 
-    await build(
-      mergeConfig(viteConfig, {
-        build: {
-          outDir: OUT_DIR,
-          emptyOutDir: true,
-          minify: false,
-          rollupOptions: {
-            input: files,
-            output: { entryFileNames: '[name].ts', format: 'es' },
-            treeshake: true,
-          },
+    const resolvedConfig: InlineConfig = mergeConfig(viteConfig, {
+      build: {
+        outDir: OUT_DIR,
+        emptyOutDir: true,
+        minify: false,
+        rollupOptions: {
+          input: files,
+          output: { entryFileNames: '[name].ts', format: 'es' },
+          treeshake: true,
         },
-        esbuild: { treeShaking: true },
-      } satisfies InlineConfig),
-    )
+      },
+      esbuild: { treeShaking: true },
+    } satisfies InlineConfig)
+
+    await build(resolvedConfig)
   }
 
   function customVitePreprocessor(file: Cypress.FileObject) {

--- a/src/vitePreprocessor.ts
+++ b/src/vitePreprocessor.ts
@@ -100,11 +100,13 @@ function vitePreprocessor(
       const rollupOutput = resolvedConfig.build.rollupOptions.output
       if (Array.isArray(rollupOutput)) {
         resolvedConfig.build.rollupOptions.output = rollupOutput.map(
-          ({ manualChunks, ...rest }) => rest,
+        // eslint-disable-next-line no-unused-vars
+            ({ manualChunks, ...rest }) => rest,
         )
       } else {
-        const { manualChunks, ...outputWithoutManualChunks } = rollupOutput
-        resolvedConfig.build.rollupOptions.output = outputWithoutManualChunks
+        // eslint-disable-next-line no-unused-vars
+        const { manualChunks, ...rest } = rollupOutput
+        resolvedConfig.build.rollupOptions.output = rest
       }
     }
 

--- a/src/vitePreprocessor.ts
+++ b/src/vitePreprocessor.ts
@@ -84,7 +84,8 @@ function vitePreprocessor(
 
     const resolvedConfig: InlineConfig & {
       build?: InlineConfig['build'] & {
-        // just copy the type from rullupOptions, so we don't have to
+        // `rolldownOptions` is used instead of `rollupOptions` in Vite 8.
+        // Just copy the type from `rollupOptions`, so we don't have to
         // maintain another type or install another package.
         rolldownOptions?: BuildEnvironmentOptions['rollupOptions']
       }

--- a/src/vitePreprocessor.ts
+++ b/src/vitePreprocessor.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { build, BuildEnvironmentOptions, type InlineConfig } from 'vite'
+import { build, type BuildEnvironmentOptions, type InlineConfig } from 'vite'
 import chokidar from 'chokidar'
 import { debug, getConfig, type CypressPreprocessor } from './common'
 import { maybeMap, omit } from './utils'

--- a/src/vitePreprocessor.ts
+++ b/src/vitePreprocessor.ts
@@ -2,9 +2,7 @@ import path from 'path'
 import { build, BuildEnvironmentOptions, type InlineConfig } from 'vite'
 import chokidar from 'chokidar'
 import { debug, getConfig, type CypressPreprocessor } from './common'
-
-const maybeMap = <I, O>(value: I | I[], modifier: (item: I) => O): O | O[] =>
-  Array.isArray(value) ? value.map(modifier) : modifier(value)
+import { maybeMap } from './utils'
 
 const watchers: Record<string, chokidar.FSWatcher> = {}
 

--- a/src/vitePreprocessor.ts
+++ b/src/vitePreprocessor.ts
@@ -78,20 +78,37 @@ function vitePreprocessor(
           formats: ['umd'],
           name: filenameWithoutExtension,
         },
-        rollupOptions: {
-          output: {
-            // override any manualChunks from the user config because they don't work with UMD
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            manualChunks: false as any,
-          },
-        },
+        // Just delete manualChunks rather than trying to override/merge
+        // rollupOptions: {
+        //   output: {
+        //     manualChunks: undefined ,
+        //   },
+        // },
       },
     }
 
-    await build({
+    const resolvedConfig: InlineConfig = {
       ...config,
       ...defaultConfig,
-    })
+    }
+
+    // Remove any manualChunks.
+    // Have tried various ways of overriding value, but can't find a value that
+    // works with both rollup and rolldown. Straight-up deletion seems to be the
+    // best move here.
+    if (resolvedConfig.build?.rollupOptions?.output) {
+      const rollupOutput = resolvedConfig.build.rollupOptions.output
+      if (Array.isArray(rollupOutput)) {
+        resolvedConfig.build.rollupOptions.output = rollupOutput.map(
+          ({ manualChunks: _, ...rest }) => rest,
+        )
+      } else {
+        const { manualChunks: _, ...outputWithoutManualChunks } = rollupOutput
+        resolvedConfig.build.rollupOptions.output = outputWithoutManualChunks
+      }
+    }
+
+    await build(resolvedConfig)
 
     return outputPath
   }

--- a/src/vitePreprocessor.ts
+++ b/src/vitePreprocessor.ts
@@ -2,7 +2,7 @@ import path from 'path'
 import { build, BuildEnvironmentOptions, type InlineConfig } from 'vite'
 import chokidar from 'chokidar'
 import { debug, getConfig, type CypressPreprocessor } from './common'
-import { maybeMap } from './utils'
+import { maybeMap, omit } from './utils'
 
 const watchers: Record<string, chokidar.FSWatcher> = {}
 
@@ -99,20 +99,7 @@ function vitePreprocessor(
       if (resolvedConfig.build?.[key]?.output) {
         resolvedConfig.build[key].output = maybeMap(
           resolvedConfig.build[key].output,
-          (o) => {
-            // omit these options to delete them
-            const {
-              manualChunks: _mc,
-              advancedChunks: _ac,
-              codeSplitting: _cs,
-              ...rest
-            } = o as typeof o & {
-              manualChunks?: unknown
-              advancedChunks?: unknown
-              codeSplitting?: unknown
-            }
-            return rest
-          },
+          (o) => omit(o, 'manualChunks', 'advancedChunks', 'codeSplitting'),
         )
       }
     }

--- a/src/vitePreprocessor.ts
+++ b/src/vitePreprocessor.ts
@@ -99,7 +99,17 @@ function vitePreprocessor(
       if (resolvedConfig.build?.[key]?.output) {
         resolvedConfig.build[key].output = maybeMap(
           resolvedConfig.build[key].output,
-          (o) => omit(o, 'manualChunks', 'advancedChunks', 'codeSplitting'),
+          (o) =>
+            omit(
+              o as typeof o & {
+                manualChunks?: unknown
+                advancedChunks?: unknown
+                codeSplitting?: unknown
+              },
+              'manualChunks',
+              'advancedChunks',
+              'codeSplitting',
+            ),
         )
       }
     }

--- a/src/vitePreprocessor.ts
+++ b/src/vitePreprocessor.ts
@@ -100,10 +100,10 @@ function vitePreprocessor(
       const rollupOutput = resolvedConfig.build.rollupOptions.output
       if (Array.isArray(rollupOutput)) {
         resolvedConfig.build.rollupOptions.output = rollupOutput.map(
-          ({ manualChunks: _, ...rest }) => rest,
+          ({ manualChunks, ...rest }) => rest,
         )
       } else {
-        const { manualChunks: _, ...outputWithoutManualChunks } = rollupOutput
+        const { manualChunks, ...outputWithoutManualChunks } = rollupOutput
         resolvedConfig.build.rollupOptions.output = outputWithoutManualChunks
       }
     }

--- a/src/vitePreprocessor.ts
+++ b/src/vitePreprocessor.ts
@@ -1,7 +1,34 @@
 import path from 'path'
-import { build, type InlineConfig } from 'vite'
+import { build, BuildEnvironmentOptions, type InlineConfig } from 'vite'
 import chokidar from 'chokidar'
 import { debug, getConfig, type CypressPreprocessor } from './common'
+
+// get from Vite config type rather than from Rollup directly, since we don't
+/// have rollup as a dependency
+type RollupOutput = Exclude<
+  Exclude<BuildEnvironmentOptions['rollupOptions'], undefined>['output'],
+  undefined
+>
+
+type ExtractElement<T> = T extends (infer U)[] ? U : T
+// advancedChunks may be present when vite-rolldown is used
+type RollupOutputOptions = ExtractElement<RollupOutput> & {
+  advancedChunks?: unknown
+}
+
+function cleanRollupOutputOptions(
+  rollupOutputOption: RollupOutputOptions,
+): Omit<RollupOutputOptions, 'manualChunks' | 'advancedChunks'> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { manualChunks: _, advancedChunks: __, ...rest } = rollupOutputOption
+  return rest
+}
+
+function cleanRollupOutput(rollupOutput: RollupOutput) {
+  return Array.isArray(rollupOutput)
+    ? rollupOutput.map(cleanRollupOutputOptions)
+    : cleanRollupOutputOptions(rollupOutput)
+}
 
 const watchers: Record<string, chokidar.FSWatcher> = {}
 
@@ -87,7 +114,11 @@ function vitePreprocessor(
       },
     }
 
-    const resolvedConfig: InlineConfig = {
+    const resolvedConfig: InlineConfig & {
+      build?: BuildEnvironmentOptions & {
+        rolldownOptions?: BuildEnvironmentOptions['rollupOptions']
+      }
+    } = {
       ...config,
       ...defaultConfig,
     }
@@ -96,17 +127,11 @@ function vitePreprocessor(
     // Have tried various ways of overriding value, but can't find a value that
     // works with both rollup and rolldown. Straight-up deletion seems to be the
     // best move here.
-    if (resolvedConfig.build?.rollupOptions?.output) {
-      const rollupOutput = resolvedConfig.build.rollupOptions.output
-      if (Array.isArray(rollupOutput)) {
-        resolvedConfig.build.rollupOptions.output = rollupOutput.map(
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          ({ manualChunks: _, ...rest }) => rest,
+    for (const key of ['rollupOptions', 'rolldownOptions'] as const) {
+      if (resolvedConfig.build?.[key]?.output) {
+        resolvedConfig.build[key].output = cleanRollupOutput(
+          resolvedConfig.build[key].output,
         )
-      } else {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { manualChunks: _, ...rest } = rollupOutput
-        resolvedConfig.build.rollupOptions.output = rest
       }
     }
 

--- a/src/vitePreprocessor.ts
+++ b/src/vitePreprocessor.ts
@@ -100,12 +100,12 @@ function vitePreprocessor(
       const rollupOutput = resolvedConfig.build.rollupOptions.output
       if (Array.isArray(rollupOutput)) {
         resolvedConfig.build.rollupOptions.output = rollupOutput.map(
-        // eslint-disable-next-line no-unused-vars
-            ({ manualChunks, ...rest }) => rest,
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars omitting manualChunks
+          ({ manualChunks: _, ...rest }) => rest,
         )
       } else {
-        // eslint-disable-next-line no-unused-vars
-        const { manualChunks, ...rest } = rollupOutput
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars omitting manualChunks
+        const { manualChunks: _, ...rest } = rollupOutput
         resolvedConfig.build.rollupOptions.output = rest
       }
     }

--- a/src/vitePreprocessor.ts
+++ b/src/vitePreprocessor.ts
@@ -100,12 +100,17 @@ function vitePreprocessor(
         resolvedConfig.build[key].output = maybeMap(
           resolvedConfig.build[key].output,
           (o) => {
-            const { manualChunks, advancedChunks, codeSplitting, ...rest } =
-              o as typeof o & {
-                manualChunks?: unknown
-                advancedChunks?: unknown
-                codeSplitting?: unknown
-              }
+            // omit these options to delete them
+            const {
+              manualChunks: _mc,
+              advancedChunks: _ac,
+              codeSplitting: _cs,
+              ...rest
+            } = o as typeof o & {
+              manualChunks?: unknown
+              advancedChunks?: unknown
+              codeSplitting?: unknown
+            }
             return rest
           },
         )

--- a/src/vitePreprocessor.ts
+++ b/src/vitePreprocessor.ts
@@ -100,11 +100,11 @@ function vitePreprocessor(
       const rollupOutput = resolvedConfig.build.rollupOptions.output
       if (Array.isArray(rollupOutput)) {
         resolvedConfig.build.rollupOptions.output = rollupOutput.map(
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars omitting manualChunks
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
           ({ manualChunks: _, ...rest }) => rest,
         )
       } else {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars omitting manualChunks
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { manualChunks: _, ...rest } = rollupOutput
         resolvedConfig.build.rollupOptions.output = rest
       }

--- a/src/vitePreprocessor.ts
+++ b/src/vitePreprocessor.ts
@@ -3,32 +3,8 @@ import { build, BuildEnvironmentOptions, type InlineConfig } from 'vite'
 import chokidar from 'chokidar'
 import { debug, getConfig, type CypressPreprocessor } from './common'
 
-// get from Vite config type rather than from Rollup directly, since we don't
-/// have rollup as a dependency
-type RollupOutput = Exclude<
-  Exclude<BuildEnvironmentOptions['rollupOptions'], undefined>['output'],
-  undefined
->
-
-type ExtractElement<T> = T extends (infer U)[] ? U : T
-// advancedChunks may be present when vite-rolldown is used
-type RollupOutputOptions = ExtractElement<RollupOutput> & {
-  advancedChunks?: unknown
-}
-
-function cleanRollupOutputOptions(
-  rollupOutputOption: RollupOutputOptions,
-): Omit<RollupOutputOptions, 'manualChunks' | 'advancedChunks'> {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { manualChunks: _, advancedChunks: __, ...rest } = rollupOutputOption
-  return rest
-}
-
-function cleanRollupOutput(rollupOutput: RollupOutput) {
-  return Array.isArray(rollupOutput)
-    ? rollupOutput.map(cleanRollupOutputOptions)
-    : cleanRollupOutputOptions(rollupOutput)
-}
+const maybeMap = <I, O>(value: I | I[], modifier: (item: I) => O): O | O[] =>
+  Array.isArray(value) ? value.map(modifier) : modifier(value)
 
 const watchers: Record<string, chokidar.FSWatcher> = {}
 
@@ -105,17 +81,13 @@ function vitePreprocessor(
           formats: ['umd'],
           name: filenameWithoutExtension,
         },
-        // Just delete manualChunks rather than trying to override/merge
-        // rollupOptions: {
-        //   output: {
-        //     manualChunks: undefined ,
-        //   },
-        // },
       },
     }
 
     const resolvedConfig: InlineConfig & {
-      build?: BuildEnvironmentOptions & {
+      build?: InlineConfig['build'] & {
+        // just copy the type from rullupOptions, so we don't have to
+        // maintain another type or install another package.
         rolldownOptions?: BuildEnvironmentOptions['rollupOptions']
       }
     } = {
@@ -123,14 +95,20 @@ function vitePreprocessor(
       ...defaultConfig,
     }
 
-    // Remove any manualChunks.
-    // Have tried various ways of overriding value, but can't find a value that
-    // works with both rollup and rolldown. Straight-up deletion seems to be the
-    // best move here.
+    // Remove any manualChunks or advancedChunks.
     for (const key of ['rollupOptions', 'rolldownOptions'] as const) {
       if (resolvedConfig.build?.[key]?.output) {
-        resolvedConfig.build[key].output = cleanRollupOutput(
+        resolvedConfig.build[key].output = maybeMap(
           resolvedConfig.build[key].output,
+          (o) => {
+            const { manualChunks, advancedChunks, codeSplitting, ...rest } =
+              o as typeof o & {
+                manualChunks?: unknown
+                advancedChunks?: unknown
+                codeSplitting?: unknown
+              }
+            return rest
+          },
         )
       }
     }


### PR DESCRIPTION
Fixes the issue brought up by this PR: https://github.com/mammadataei/cypress-vite/pull/136 but provides a fix that works for both `rollup` and `rolldown`. Have tried too many times to find the right value to override for `manualChunks`... let's just delete it.