### PR TITLE
feat: move all deps to peerDeps

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -45,50 +45,64 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-
     strategy:
       fail-fast: false
       matrix:
         include:
+          - &matrix-defaults
+            vite-version: 8
+            plugin-react-version: 6
+            cypress-version: 14
+            chokidar-version: 5
+            debug-version: 4
+
           # Each permitted Vite version against same version of Cypress
-          - vite-version: '2.9'
-            cypress-version: 14
-            plugin-react-version: '1'
-          - vite-version: '3'
-            cypress-version: 14
-            plugin-react-version: '2'
-          - vite-version: '4'
-            cypress-version: 14
-            plugin-react-version: '3'
-          - vite-version: '5'
-            cypress-version: 14
-            plugin-react-version: '4'
-          - vite-version: '6'
-            cypress-version: 14
-            plugin-react-version: '4'
-          - vite-version: '7'
-            cypress-version: 14
-            plugin-react-version: '4'
-          - vite-version: '8'
-            cypress-version: 14
-            plugin-react-version: '6'
-          # Each Cypress version against latest permitted Vite version
-          - vite-version: '8'
+          - <<: *matrix-defaults
+            vite-version: '2.9'
+            plugin-react-version: 1
+          - <<: *matrix-defaults
+            vite-version: 3
+            plugin-react-version: 2
+          - <<: *matrix-defaults
+            vite-version: 4
+            plugin-react-version: 3
+          - <<: *matrix-defaults
+            vite-version: 5
+            plugin-react-version: 4
+          - <<: *matrix-defaults
+            vite-version: 6
+            plugin-react-version: 4
+          - <<: *matrix-defaults
+            vite-version: 7
+            plugin-react-version: 4
+          # default values, are tested below.
+          # - <<: *matrix-defaults
+          #   vite-version: 8
+          #   plugin-react-version: 6
+
+          # Each Cypress version against latest permitted Vite version,
+          # testing permitted versions of other peerDependencies at the same time.
+          - <<: *matrix-defaults
             cypress-version: 12
-            plugin-react-version: '6'
-          - vite-version: '8'
+            chokidar-version: 2
+            debug-version: 2
+          - <<: *matrix-defaults
             cypress-version: 13
-            plugin-react-version: '6'
-          - vite-version: '8'
+            chokidar-version: 3
+            debug-version: 2
+          - <<: *matrix-defaults
             cypress-version: 14
-            plugin-react-version: '6'
-          - vite-version: '8'
+            chokidar-version: 4
+            debug-version: 3
+          - <<: *matrix-defaults
             cypress-version: 15
-            plugin-react-version: '6'
+            chokidar-version: 5
+            debug-version: 4
 
     name:
       test (vite@${{ matrix.vite-version }}, cypress@${{ matrix.cypress-version
-      }})
+      }}, chokidar@${{ matrix.chokidar-version }}, debug@${{
+      matrix.debug-version }})
 
     steps:
       - uses: actions/checkout@v6
@@ -107,32 +121,31 @@ jobs:
 
       - uses: actions/cache@v5
         name: Setup pnpm cache
+        env:
+          CACHE_KEY_PREFIX:
+            ${{ runner.os }}-pnpm-store-vite${{ matrix.vite-version
+            }}-cypress${{ matrix.cypress-version }}-chokidar${{
+            matrix.chokidar-version }}-debug${{ matrix.debug-version }}
         with:
           path: |
             ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
             ~/.cache/Cypress
-          key:
-            ${{ runner.os }}-pnpm-store-vite${{ matrix.vite-version
-            }}-cypress${{ matrix.cypress-version }}-${{
-            hashFiles('**/pnpm-lock.yaml') }}
+          key: ${{ env.CACHE_KEY_PREFIX }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
-            ${{ runner.os }}-pnpm-store-vite${{ matrix.vite-version }}-cypress${{ matrix.cypress-version }}-
-            ${{ runner.os }}-pnpm-store-vite${{ matrix.vite-version }}-
-            ${{ runner.os }}-pnpm-store-
+            ${{ env.CACHE_KEY_PREFIX }}-
 
       - name: Install dependencies
         run: pnpm i
 
-      - name: Override Vite version
+      - name: Override dependency versions
         run:
           pnpm --filter example add vite@${{ matrix.vite-version }}
-          @vitejs/plugin-react@${{ matrix.plugin-react-version }}
-
-      - name: Override Cypress version
-        run: pnpm --filter example add cypress@${{ matrix.cypress-version }}
+          @vitejs/plugin-react@${{ matrix.plugin-react-version }} cypress@${{
+          matrix.cypress-version }} chokidar@${{ matrix.chokidar-version }}
+          debug@${{ matrix.debug-version }}
 
       - name: Run Tests
-        uses: cypress-io/github-action@v7.1.10
+        uses: cypress-io/github-action@v7.3.0
         with:
           install: false
           build: pnpm build

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -45,64 +45,53 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    env:
+      DEFAULT_VITE_VERSION: 8
+      DEFAULT_PLUGIN_REACT_VERSION: 6
+      DEFAULT_CYPRESS_VERSION: 14
+      DEFAULT_CHOKIDAR_VERSION: 5
+      DEFAULT_DEBUG_VERSION: 4
+
     strategy:
       fail-fast: false
       matrix:
         include:
-          - &matrix-defaults
-            vite-version: 8
-            plugin-react-version: 6
-            cypress-version: 14
-            chokidar-version: 5
-            debug-version: 4
-
           # Each permitted Vite version against same version of Cypress
-          - <<: *matrix-defaults
-            vite-version: '2.9'
+          - vite-version: '2.9'
             plugin-react-version: 1
-          - <<: *matrix-defaults
-            vite-version: 3
+          - vite-version: 3
             plugin-react-version: 2
-          - <<: *matrix-defaults
-            vite-version: 4
+          - vite-version: 4
             plugin-react-version: 3
-          - <<: *matrix-defaults
-            vite-version: 5
+          - vite-version: 5
             plugin-react-version: 4
-          - <<: *matrix-defaults
-            vite-version: 6
+          - vite-version: 6
             plugin-react-version: 4
-          - <<: *matrix-defaults
-            vite-version: 7
+          - vite-version: 7
             plugin-react-version: 4
           # default values, are tested below.
-          # - <<: *matrix-defaults
-          #   vite-version: 8
+          # - vite-version: 8
           #   plugin-react-version: 6
 
           # Each Cypress version against latest permitted Vite version,
           # testing permitted versions of other peerDependencies at the same time.
-          - <<: *matrix-defaults
-            cypress-version: 12
+          - cypress-version: 12
             chokidar-version: 2
             debug-version: 2
-          - <<: *matrix-defaults
-            cypress-version: 13
+          - cypress-version: 13
             chokidar-version: 3
             debug-version: 2
-          - <<: *matrix-defaults
-            cypress-version: 14
+          - cypress-version: 14
             chokidar-version: 4
             debug-version: 3
-          - <<: *matrix-defaults
-            cypress-version: 15
+          - cypress-version: 15
             chokidar-version: 5
             debug-version: 4
 
     name:
-      test (vite@${{ matrix.vite-version }}, cypress@${{ matrix.cypress-version
-      }}, chokidar@${{ matrix.chokidar-version }}, debug@${{
-      matrix.debug-version }})
+      test (vite@${{ matrix.vite-version || 8 }}, cypress@${{
+      matrix.cypress-version || 14 }}, chokidar@${{ matrix.chokidar-version || 5
+      }}, debug@${{ matrix.debug-version || 4 }})
 
     steps:
       - uses: actions/checkout@v6
@@ -114,6 +103,16 @@ jobs:
         with:
           node-version: 22.x
 
+      - name: Resolve effective dependency versions
+        id: versions
+        shell: bash
+        run: |
+          echo "vite=${{ matrix.vite-version || env.DEFAULT_VITE_VERSION }}" >> "$GITHUB_OUTPUT"
+          echo "plugin_react=${{ matrix.plugin-react-version || env.DEFAULT_PLUGIN_REACT_VERSION }}" >> "$GITHUB_OUTPUT"
+          echo "cypress=${{ matrix.cypress-version || env.DEFAULT_CYPRESS_VERSION }}" >> "$GITHUB_OUTPUT"
+          echo "chokidar=${{ matrix.chokidar-version || env.DEFAULT_CHOKIDAR_VERSION }}" >> "$GITHUB_OUTPUT"
+          echo "debug=${{ matrix.debug-version || env.DEFAULT_DEBUG_VERSION }}" >> "$GITHUB_OUTPUT"
+
       - name: Get pnpm store directory
         id: pnpm-cache
         run: |
@@ -123,9 +122,10 @@ jobs:
         name: Setup pnpm cache
         env:
           CACHE_KEY_PREFIX:
-            ${{ runner.os }}-pnpm-store-vite${{ matrix.vite-version
-            }}-cypress${{ matrix.cypress-version }}-chokidar${{
-            matrix.chokidar-version }}-debug${{ matrix.debug-version }}
+            ${{ runner.os }}-pnpm-store-vite${{ steps.versions.outputs.vite
+            }}-cypress${{ steps.versions.outputs.cypress }}-chokidar${{
+            steps.versions.outputs.chokidar }}-debug${{
+            steps.versions.outputs.debug }}
         with:
           path: |
             ${{ steps.pnpm-cache.outputs.pnpm_cache_dir }}
@@ -139,10 +139,11 @@ jobs:
 
       - name: Override dependency versions
         run:
-          pnpm --filter example add vite@${{ matrix.vite-version }}
-          @vitejs/plugin-react@${{ matrix.plugin-react-version }} cypress@${{
-          matrix.cypress-version }} chokidar@${{ matrix.chokidar-version }}
-          debug@${{ matrix.debug-version }}
+          pnpm --filter example add vite@${{ steps.versions.outputs.vite }}
+          @vitejs/plugin-react@${{ steps.versions.outputs.plugin_react }}
+          cypress@${{ steps.versions.outputs.cypress }} chokidar@${{
+          steps.versions.outputs.chokidar }} debug@${{
+          steps.versions.outputs.debug }}
 
       - name: Run Tests
         uses: cypress-io/github-action@v7.3.0

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "*.{js,jsx,ts,tsx,md,html,css}": "prettier --write"
   },
   "peerDependencies": {
-    "vite": "^2.9 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8"
+    "vite": "^2.9 || ^3 || ^4 || ^5 || ^6 || ^7 || ^8",
+    "chokidar": "^2 || ^3 || ^4 || ^5",
+    "debug": "^2 || ^3 || ^4"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.0.0",
@@ -55,6 +57,7 @@
     "@typescript-eslint/eslint-plugin": "^8.59.0",
     "@typescript-eslint/parser": "^8.59.0",
     "cypress": "^15.0.0",
+    "debug": "^4.4.3",
     "eslint": "^10.3.0",
     "eslint-config-prettier": "^10.1.0",
     "husky": "^9.1.7",
@@ -62,11 +65,9 @@
     "prettier": "^3.8.0",
     "typescript": "^6.0.0",
     "unbuild": "^3.5.0",
-    "vite": "^8.0.0"
+    "vite": "^8.0.0",
+    "chokidar": "^5.0.0"
   },
-  "dependencies": {
-    "chokidar": "^3.5.3",
-    "debug": "^4.4.3"
-  },
+  "dependencies": {},
   "packageManager": "pnpm@9.15.9"
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@types/node": "^24.1.0",
     "@typescript-eslint/eslint-plugin": "^8.59.0",
     "@typescript-eslint/parser": "^8.59.0",
+    "chokidar": "^5.0.0",
     "cypress": "^15.0.0",
     "debug": "^4.4.3",
     "eslint": "^10.3.0",
@@ -65,8 +66,7 @@
     "prettier": "^3.8.0",
     "typescript": "^6.0.0",
     "unbuild": "^3.5.0",
-    "vite": "^8.0.0",
-    "chokidar": "^5.0.0"
+    "vite": "^8.0.0"
   },
   "dependencies": {},
   "packageManager": "pnpm@9.15.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,13 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      chokidar:
-        specifier: ^3.5.3
-        version: 3.6.0
-      debug:
-        specifier: ^4.4.3
-        version: 4.4.3(supports-color@8.1.1)
     devDependencies:
       '@commitlint/cli':
         specifier: ^20.0.0
@@ -33,9 +26,15 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.59.0
         version: 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
       cypress:
         specifier: ^15.0.0
         version: 15.14.2
+      debug:
+        specifier: ^4.4.3
+        version: 4.4.3(supports-color@8.1.1)
       eslint:
         specifier: ^10.3.0
         version: 10.3.0(jiti@2.6.1)
@@ -1099,6 +1098,10 @@ packages:
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
 
   ci-info@4.1.0:
     resolution: {integrity: sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==}
@@ -2452,6 +2455,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  readdirp@5.0.0:
+    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+    engines: {node: '>= 20.19.0'}
+
   request-progress@3.0.0:
     resolution: {integrity: sha512-MnWzEHHaxHO2iWiQuHrUPBi/1WeBf5PkxQqNyNvLl9VAYSdXkP8tQ3pBSeCPD+yw0v0Aq1zosWLz0BdeXpWwZg==}
 
@@ -3763,6 +3770,10 @@ snapshots:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.3
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.0.0
 
   ci-info@4.1.0: {}
 
@@ -5093,6 +5104,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  readdirp@5.0.0: {}
 
   request-progress@3.0.0:
     dependencies:


### PR DESCRIPTION
Stems from request by @nerdstep in https://github.com/mammadataei/cypress-vite/issues/177#issuecomment-4372128831

These dependencies are used incredibly simply in the `cypress-vite` package, meaning that multiple major versions work and are acceptable. Due to this, move to `peerDependencies` to allow for user to use whatever version they already have in their project.

**In doing so, add tests to ensure that all allowed versions do not cause issues.**
