### PR TITLE
fix: unique prebuild paths for same-basename specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build": "unbuild",
     "example": "pnpm --filter example",
     "test": "pnpm --filter example test",
+    "test:unit": "node --experimental-strip-types --test test/prebuild-unique-spec-paths.test.mts",
     "format": "prettier --write . && pnpm lint --fix",
     "lint": "eslint . ",
     "check": "tsc && pnpm lint && prettier --check .",

--- a/src/vitePrebuild.ts
+++ b/src/vitePrebuild.ts
@@ -4,6 +4,22 @@ import baseVitePreprocessor from './vitePreprocessor'
 import { debug, getConfig } from './common'
 
 let wasPrebuilt = true
+let prebuildRoot = ''
+
+/**
+ * Rollup `[name]` for a spec, relative to the Cypress/project root.
+ * Using `path.basename` here collides when two specs share a filename.
+ */
+function getPrebuildEntryName(filePath: string, root: string): string {
+  const relative = path.relative(root, filePath)
+  const posix = relative.split(path.sep).join('/')
+  const { dir, name } = path.posix.parse(posix)
+  return path.posix.join(dir, name)
+}
+
+function getPrebuildOutputPath(filePath: string, root: string, outDir: string) {
+  return path.join(outDir, `${getPrebuildEntryName(filePath, root)}.ts`)
+}
 
 /**
  * Pre-process all files at the beginning of the test run, before they are ran through the
@@ -62,6 +78,14 @@ export function getVitePrebuilder(userConfig?: InlineConfig | string) {
 
     debug(`Pre-building ${files.length} files with Vite.`)
 
+    prebuildRoot = cypressConfig.projectRoot || process.cwd()
+    const input = Object.fromEntries(
+      files.map((filePath) => [
+        getPrebuildEntryName(filePath, prebuildRoot),
+        filePath,
+      ]),
+    )
+
     const resolvedConfig: InlineConfig = mergeConfig(config, {
       // overrides
       build: {
@@ -69,7 +93,7 @@ export function getVitePrebuilder(userConfig?: InlineConfig | string) {
         emptyOutDir: true,
         minify: false,
         rollupOptions: {
-          input: files,
+          input,
           output: { entryFileNames: '[name].ts', format: 'es' },
           treeshake: true,
         },
@@ -82,7 +106,8 @@ export function getVitePrebuilder(userConfig?: InlineConfig | string) {
 
   function customVitePreprocessor(file: Cypress.FileObject) {
     if (wasPrebuilt && !file.shouldWatch) {
-      file.filePath = path.join(OUT_DIR, path.basename(file.filePath))
+      const root = prebuildRoot || process.cwd()
+      file.filePath = getPrebuildOutputPath(file.filePath, root, OUT_DIR)
     }
 
     // TODO: make so initial preprocess works, don't have to re-preprocess here

--- a/test/prebuild-unique-spec-paths.test.mts
+++ b/test/prebuild-unique-spec-paths.test.mts
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict'
+import { EventEmitter } from 'node:events'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { after, before, describe, it } from 'node:test'
+import { getVitePrebuilder } from '../dist/index.mjs'
+
+const PREBUILD_OUT_DIR = 'node_modules/.cypress-vite-prebuild'
+
+function listFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return []
+  const files: string[] = []
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name)
+    if (entry.isDirectory()) files.push(...listFiles(full))
+    else files.push(full)
+  }
+  return files
+}
+
+function makeFile(filePath: string, outputPath: string) {
+  const file = new EventEmitter() as EventEmitter & {
+    filePath: string
+    outputPath: string
+    shouldWatch: boolean
+  }
+  file.filePath = filePath
+  file.outputPath = outputPath
+  file.shouldWatch = false
+  return file
+}
+
+describe('prebuild unique spec paths (#261)', () => {
+  const originalCwd = process.cwd()
+  let projectRoot = ''
+  let specA = ''
+  let specB = ''
+  let outDir = ''
+  let vitePrebuild: ReturnType<typeof getVitePrebuilder>['vitePrebuild']
+  let vitePreprocessor: ReturnType<typeof getVitePrebuilder>['vitePreprocessor']
+
+  before(async () => {
+    projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cypress-vite-261-'))
+    specA = path.join(projectRoot, 'a', 'test.cy.ts')
+    specB = path.join(projectRoot, 'b', 'test.cy.ts')
+    fs.mkdirSync(path.dirname(specA), { recursive: true })
+    fs.mkdirSync(path.dirname(specB), { recursive: true })
+    fs.writeFileSync(specA, 'console.log("SPEC_A_MARKER")\n')
+    fs.writeFileSync(specB, 'console.log("SPEC_B_MARKER")\n')
+    outDir = path.join(projectRoot, PREBUILD_OUT_DIR)
+
+    process.chdir(projectRoot)
+
+    const prebuilder = getVitePrebuilder({
+      configFile: false,
+      root: projectRoot,
+      logLevel: 'error',
+    })
+    vitePrebuild = prebuilder.vitePrebuild
+    vitePreprocessor = prebuilder.vitePreprocessor
+
+    await vitePrebuild(
+      {
+        specs: [{ absolute: specA }, { absolute: specB }],
+      } as Cypress.BeforeRunDetails,
+      {
+        watchForFileChanges: false,
+        supportFile: false,
+        projectRoot,
+      } as Cypress.PluginConfigOptions,
+    )
+  })
+
+  after(() => {
+    process.chdir(originalCwd)
+    fs.rmSync(projectRoot, { recursive: true, force: true })
+  })
+
+  it('emits distinct nested outputs for same-basename specs', () => {
+    const emitted = listFiles(outDir)
+    const rel = emitted.map((file) =>
+      path.relative(outDir, file).split(path.sep).join('/'),
+    )
+
+    const outA = path.join(outDir, 'a', 'test.cy.ts')
+    const outB = path.join(outDir, 'b', 'test.cy.ts')
+
+    assert.ok(
+      fs.existsSync(outA),
+      `expected ${path.relative(outDir, outA)} under prebuild outDir, got: ${rel.join(', ') || '(empty)'}`,
+    )
+    assert.ok(
+      fs.existsSync(outB),
+      `expected ${path.relative(outDir, outB)} under prebuild outDir, got: ${rel.join(', ') || '(empty)'}`,
+    )
+    assert.notEqual(outA, outB)
+
+    const contentA = fs.readFileSync(outA, 'utf8')
+    const contentB = fs.readFileSync(outB, 'utf8')
+    assert.match(contentA, /SPEC_A_MARKER/)
+    assert.doesNotMatch(contentA, /SPEC_B_MARKER/)
+    assert.match(contentB, /SPEC_B_MARKER/)
+    assert.doesNotMatch(contentB, /SPEC_A_MARKER/)
+  })
+
+  it('maps each spec to its own prebuild output, not path.basename', async () => {
+    const outputA = path.join(projectRoot, 'out-a.js')
+    const outputB = path.join(projectRoot, 'out-b.js')
+
+    await vitePreprocessor(makeFile(specA, outputA) as Cypress.FileObject)
+    await vitePreprocessor(makeFile(specB, outputB) as Cypress.FileObject)
+
+    const bundledA = fs.readFileSync(outputA, 'utf8')
+    const bundledB = fs.readFileSync(outputB, 'utf8')
+    assert.match(bundledA, /SPEC_A_MARKER/)
+    assert.doesNotMatch(bundledA, /SPEC_B_MARKER/)
+    assert.match(bundledB, /SPEC_B_MARKER/)
+    assert.doesNotMatch(bundledB, /SPEC_A_MARKER/)
+    assert.equal(path.basename(specA), path.basename(specB))
+  })
+})


### PR DESCRIPTION
## Summary

When prebuilding, Rollup `entryFileNames: '[name].ts'` plus a `path.basename` lookup flattened every spec to its filename. Two specs that share a basename in different folders (`a/test.cy.ts` and `b/test.cy.ts`) emitted `test.cy.ts` / `test2.cy.ts`, and the preprocessor always loaded `test.cy.ts`.

Name each prebuild entry from the spec path relative to the Cypress/project root so Vite emits a nested file, and resolve `file.filePath` with the same mapping.

Credits @jojoxd for the report and the relative-path suggestion.

Fixes #261

## Test plan

- [x] On unmodified `main`, `pnpm build && pnpm test:unit` fails: prebuild emits `test.cy.ts` + `test2.cy.ts`; spec B's preprocessor output contains spec A's marker
- [x] After this change, both unit tests pass (distinct `a/test.cy.ts` / `b/test.cy.ts` artifacts and correct preprocessor mapping)
- [x] `pnpm check` (tsc, eslint, prettier)
